### PR TITLE
chore: reverse query params order to display summary for >4096char urls

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -46,8 +46,8 @@ const Input = ({
           ))}
           <span
             className={`z-1 absolute left-2 right-auto h-[calc(100%-1rem)] w-[calc(33.33%-0.5rem)] rounded-full bg-white transition-all duration-200 ease-in-out ${
-              inputTypeSelected === InputType.TEXT && "left-1/2 -translate-x-1/2"
-            } ${inputTypeSelected === InputType.SONG && "left-2/3 right-2"}`}
+              inputTypeSelected === InputType.TEXT && "!left-1/2 !-translate-x-1/2"
+            } ${inputTypeSelected === InputType.SONG && "!left-2/3 !right-2"}`}
           ></span>
         </div>
         {inputTypeSelected === InputType.WEBSITE && (

--- a/src/components/Result/ResultPageHeader.tsx
+++ b/src/components/Result/ResultPageHeader.tsx
@@ -28,7 +28,7 @@ const ResultPageHeader = ({
           </div>
           <div className="relative flex-1 text-right">
             <button
-              className="group relative mx-auto inline-flex h-[3.4rem] min-w-[11.1rem] items-center justify-center overflow-hidden rounded-full border-2 border-white bg-transparent px-5 py-3  text-white md:h-20 md:min-w-[18rem] md:border-primary  md:text-primary"
+              className="group relative mx-auto inline-flex h-[3.4rem] min-w-[11.1rem] items-center justify-center overflow-hidden rounded-full border-2 border-white bg-transparent px-5 py-3  text-white will-change-transform md:h-20 md:min-w-[18rem]  md:border-primary md:text-primary"
               type="button"
               onClick={() => handleNewSearchBtnClick()}
             >

--- a/src/components/utility-components/result/ResultPageContentToggler.tsx
+++ b/src/components/utility-components/result/ResultPageContentToggler.tsx
@@ -25,7 +25,7 @@ const ResultPageContentToggler = ({ resultPageContent, setResultPageContent }: R
       </button>
       <span
         className={`z-1 absolute left-2 right-auto h-[calc(100%-1rem)] w-[calc(50%-0.5rem)] rounded-full bg-white transition-all ease-in-out ${
-          resultPageContent === "original" && "left-1/2 right-2"
+          resultPageContent === "original" && "!left-1/2 !right-2"
         }`}
       ></span>
     </div>

--- a/src/utils/generateLinkToShare.ts
+++ b/src/utils/generateLinkToShare.ts
@@ -2,8 +2,8 @@ import { ResponseType } from "~/types";
 
 export function encodeStateToUrl(originalContent: string, responseObject: ResponseType): string {
   const baseUrl = process.env.BASE_URL || window.location.origin;
-  const queryString = `?original=${encodeURIComponent(originalContent)}&result=${encodeURIComponent(
+  const queryString = `?result=${encodeURIComponent(
     JSON.stringify(responseObject),
-  )}`;
+  )}&original=${encodeURIComponent(originalContent)}`;
   return baseUrl + queryString;
 }


### PR DESCRIPTION
## WHAT IT DOES:

_Description of the pull request, what changed_

- Reversed the order of query params. We had `/?original=__&result=__` . Changed to` /?result=__&original=__`

This should temporarily fix the page breaking on safari when the url becomes > 4096 chars

- Bug fix for new summary button hover effect on safari

