### PR TITLE
feat: pass readability, fix tailwind, refactor url param, webpack config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  webpack(config) {
+  webpack(config, { webpack }) {
     config.module.rules.push({
       test: /\.svg$/i,
       issuer: /\.[jt]sx?$/,
       use: ["@svgr/webpack"],
     });
+
+    config.plugins.push(new webpack.IgnorePlugin({ resourceRegExp: /canvas/ })); // There's an issue where canvas is required for JSDOM even though it's optional
     return config;
   },
   experimental: {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "openai": "^3.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "server-only": "^0.0.1",
     "sse.js": "^0.6.1",
     "typescript": "4.9.4"
   },

--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -8,15 +8,18 @@ import Loading from "~/components/Loading/Loading";
 import Error from "~/components/Error/Error";
 import useOpenAiSSEResponse from "~/hooks/useOpenAiSSEResponse";
 import useAnalytics from "~/hooks/use-analytics";
-import { getStringOrFirst } from "~/typescript-helpers/type-cast-functions";
 
-export default function ClientPage({ searchParams }: { searchParams?: { [key: string]: string | string[] | undefined } }) {
-  const [originalContent, setOriginalContent] = useState(searchParams?.original ?? "");
+export default function ClientPage({ searchParams }: { searchParams: { [key: string]: string } }) {
+  const [originalContent, setOriginalContent] = useState(searchParams.original ?? "");
+  const urlRegex = /^(https?:\/\/)?[0-9a-z-_]*(\.[0-9a-z-_]+)*(\.[a-z]+)+(\/[0-9a-z-_]*)*?\/?$/i;
+  const [displayOriginalContent, setDisplayOriginalContent] = useState(
+    urlRegex.test(searchParams.original) ? "" : searchParams.original,
+  );
   const [displayResult, setDisplayResult] = useState<boolean>(
-    getStringOrFirst(searchParams?.original).length > 0 && getStringOrFirst(searchParams?.result).length > 0,
+    searchParams.original.length > 0 && searchParams.result.length > 0,
   );
   const [currentResult, setCurrentResult] = useState<ResponseType | null>(
-    searchParams?.result && JSON.parse(getStringOrFirst(searchParams.result)),
+    searchParams.result && JSON.parse(searchParams.result),
   );
   const [songDetails, setSongDetails] = useState("");
 
@@ -39,6 +42,9 @@ export default function ClientPage({ searchParams }: { searchParams?: { [key: st
       setDisplayResult(true);
       setCurrentResult(res);
     },
+    onReadability: (res) => {
+      setDisplayOriginalContent(res.content);
+    },
     onError: (err, data) => {
       trackRequestError({ ...data, error: (err?.message as string) ?? "" });
     },
@@ -56,6 +62,7 @@ export default function ClientPage({ searchParams }: { searchParams?: { [key: st
     setSongDetails(songInfo);
     if (type === "text") {
       setSongDetails("");
+      text?.length && setDisplayOriginalContent(text);
       text?.length && setOriginalContent(text);
     } else {
       inputUrl?.length && setOriginalContent(inputUrl);
@@ -72,6 +79,7 @@ export default function ClientPage({ searchParams }: { searchParams?: { [key: st
     setDisplayResult(false);
     setOriginalContent("");
     setCurrentResult(null);
+    setDisplayOriginalContent("");
     setSongDetails("");
     window.history.replaceState(null, "", window.location.origin);
     trackNewSummary();
@@ -100,6 +108,7 @@ export default function ClientPage({ searchParams }: { searchParams?: { [key: st
           summaryResponse={currentResult as TextSummaryResponseType | SongMeaningResponseType}
           handleNewSearchBtnClick={handleNewSearchBtnClick}
           originalContent={originalContent}
+          displayOriginalContent={displayOriginalContent}
           songDetails={songDetails}
           isLoadingSSE={isLoadingSSE}
         />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,9 @@
-@import url("https://fonts.googleapis.com/css2?family=Spline+Sans:wght@300;400;500;600;700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@700&display=swap");
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import url("https://fonts.googleapis.com/css2?family=Spline+Sans:wght@300;400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Poppins&display=swap");
 
 @layer base {
@@ -58,4 +59,8 @@
       fill: #3a2adc;
     }
   }
+}
+
+.render-span-block * > span {
+  display: block;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,36 @@
+import "server-only";
 // this seems like an open issue, search params returned empty object, so had to force-dynamic : https://github.com/vercel/next.js/issues/43077
-export const dynamic='force-dynamic';
+export const dynamic = "force-dynamic";
 
+import readability from "~/api-functions/readability";
+import { getStringOrFirst } from "~/typescript-helpers/type-cast-functions";
 import ClientPage from "./clientPage";
 
-export default function Page({ searchParams }: { searchParams?: { [key: string]: string | string[] | undefined } }) {
-  return <ClientPage searchParams={searchParams} />;
+export default async function Page({
+  searchParams,
+}: {
+  searchParams?: { [key: string]: string | string[] | undefined };
+}) {
+  const urlRegex = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b/;
+  // Fetch readability data in server and pass to client side
+  const fetchReadabilityOnLoad = async () => {
+    const original = getStringOrFirst(searchParams?.original).trim();
+    if (urlRegex.test(original)) {
+      try {
+        const json = await readability(original, 500);
+        return json.content;
+      } catch (e) {
+        console.log(e);
+        return original;
+      }
+    }
+    return original;
+  };
+
+  const parsedSearchParams = {
+    original: await fetchReadabilityOnLoad(),
+    result: getStringOrFirst(searchParams?.result),
+  };
+
+  return <ClientPage searchParams={parsedSearchParams} />;
 }

--- a/src/components/Input/InputField/SongInputField.tsx
+++ b/src/components/Input/InputField/SongInputField.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import SummaryLengthSlider from "../../utility-components/input/SummaryLengthSlider";
 import { InputFormSubmissionType } from "~/types";
 import SummarizeButton from "../../utility-components/input/SummarizeButton";
+import { generateSongUrl } from "~/utils/generate-song-url";
 
 const SongInputField = ({
   handleFormSubmit,
@@ -26,9 +27,7 @@ const SongInputField = ({
       <form
         className="flex w-full flex-col rounded-md"
         onSubmit={(event: React.SyntheticEvent) => {
-          const inputUrl = `https://www.google.com/search?q=lyrics+to+${artistName.split(" ").join("-")}+${songTitle
-            .split(" ")
-            .join("-")}`;
+          const inputUrl = generateSongUrl(artistName, songTitle);
           handleFormSubmit(event, type, summaryLength, customLength, inputUrl, "", songInfo);
         }}
       >

--- a/src/components/Result/Result.tsx
+++ b/src/components/Result/Result.tsx
@@ -8,7 +8,8 @@ import ResultPageContentToggler from "../utility-components/result/ResultPageCon
 import OriginalContent from "./ResultContent/OriginalContent";
 
 type ResultProp = {
-  originalContent: string | string[];
+  originalContent: string;
+  displayOriginalContent: string;
   summaryResponse?: TextSummaryResponseType | SongMeaningResponseType | null;
   handleNewSearchBtnClick: () => void;
   songDetails: string;
@@ -18,6 +19,7 @@ type ResultProp = {
 
 const Result = ({
   originalContent,
+  displayOriginalContent,
   summaryResponse,
   handleNewSearchBtnClick,
   trackShare,
@@ -41,6 +43,7 @@ const Result = ({
           trackShare={trackShare}
           songMeaningResponse={summaryResponse as SongMeaningResponseType}
           songDetails={songDetails}
+          originalContent={originalContent}
           isLoadingSSE={isLoadingSSE}
         />
       )}
@@ -62,9 +65,9 @@ const Result = ({
       )}
       {resultPageContent === "original" && (
         <OriginalContent
-          content={originalContent}
-          songDetails={songDetails}
+          content={displayOriginalContent}
           contentType={summaryResponse?.type || null}
+          songDetails={songDetails}
         />
       )}
       <div className="text-center">

--- a/src/components/Result/ResultContent/OriginalContent.tsx
+++ b/src/components/Result/ResultContent/OriginalContent.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Container from "../../utility-components/Container";
-import { getStringOrFirst } from "~/typescript-helpers/type-cast-functions";
 import { ContentType } from "~/types";
 
 const OriginalContent = ({
@@ -8,7 +7,7 @@ const OriginalContent = ({
   songDetails,
   contentType,
 }: {
-  content: string | string[];
+  content: string;
   songDetails: string;
   contentType: ContentType | null;
 }) => {
@@ -17,23 +16,10 @@ const OriginalContent = ({
   };
   return (
     <Container>
-      {contentType === "article" && (
-        <div className="mx-auto mb-12 max-w-[75rem] animate-fadeIn rounded-[20px] border-2 border-primary bg-white py-12 px-8 text-lg font-semibold md:my-20 md:p-20">
-          <a href={getStringOrFirst(content)} target="_blank" className="hover:underline" rel="noreferrer">
-            {getStringOrFirst(content)}
-          </a>
-        </div>
-      )}
-      {contentType === "song" && (
-        <div className="mx-auto mb-12 max-w-[75rem] rounded-[20px] border-2 border-primary bg-white py-12 px-8 text-xl font-semibold md:my-20 md:p-20">
-          {capitalize(songDetails || getStringOrFirst(content))}
-        </div>
-      )}
-      {contentType === "text" && (
-        <div className="mx-auto mb-12 max-w-[75rem] rounded-[20px] border-2 border-primary bg-white py-12 px-8 md:my-20 md:p-20">
-          {getStringOrFirst(content)}
-        </div>
-      )}
+      <article className=" mx-auto mb-12 max-w-[75rem] rounded-[20px] border-2 border-primary bg-white py-12 px-8 md:my-20 md:p-20">
+        {contentType === "song" && <div>{capitalize(songDetails ?? "")}</div>}
+        <section className="render-span-block" dangerouslySetInnerHTML={{ __html: content }} />
+      </article>
     </Container>
   );
 };

--- a/src/components/Result/ResultContent/SongResult.tsx
+++ b/src/components/Result/ResultContent/SongResult.tsx
@@ -7,11 +7,18 @@ import { encodeStateToUrl } from "~/utils/generateLinkToShare";
 type SongResultPropType = {
   songMeaningResponse: SongMeaningResponseType;
   songDetails: string;
+  originalContent: string;
   isLoadingSSE: boolean;
   trackShare: (properties: { shareURL: string }) => void;
 };
 
-const SongResult = ({ songMeaningResponse, songDetails, isLoadingSSE, trackShare }: SongResultPropType) => {
+const SongResult = ({
+  songMeaningResponse,
+  originalContent,
+  songDetails,
+  isLoadingSSE,
+  trackShare,
+}: SongResultPropType) => {
   useEffect(() => {
     if (!isLoadingSSE) {
       const encodedUrl = encodeStateToUrl(songDetails, songMeaningResponse);
@@ -27,7 +34,7 @@ const SongResult = ({ songMeaningResponse, songDetails, isLoadingSSE, trackShare
             <ShareLinkButton
               trackShare={trackShare}
               responseObject={songMeaningResponse}
-              originalContent={songDetails}
+              originalContent={originalContent}
               disabled={isLoadingSSE}
             />
           </div>
@@ -38,7 +45,7 @@ const SongResult = ({ songMeaningResponse, songDetails, isLoadingSSE, trackShare
             <ShareLinkButton
               trackShare={trackShare}
               responseObject={songMeaningResponse}
-              originalContent={songDetails}
+              originalContent={originalContent}
             />
           </div>
         )}

--- a/src/components/Result/ResultContent/TextResult.tsx
+++ b/src/components/Result/ResultContent/TextResult.tsx
@@ -3,10 +3,9 @@ import { TextSummaryResponseType, TextResponse } from "~/types";
 import ShareLinkButton from "../../utility-components/result/ShareLinkButton";
 import { useEffect } from "react";
 import { encodeStateToUrl } from "~/utils/generateLinkToShare";
-import { getStringOrFirst } from "~/typescript-helpers/type-cast-functions";
 
 type TextResultPropType = {
-  originalContent: string | string[];
+  originalContent: string;
   textSummaryResponse: TextSummaryResponseType | TextResponse;
   isLoadingSSE: boolean;
   trackShare: (properties: { shareURL: string }) => void;
@@ -15,7 +14,7 @@ type TextResultPropType = {
 const TextResult = ({ originalContent, textSummaryResponse, isLoadingSSE, trackShare }: TextResultPropType) => {
   useEffect(() => {
     if (!isLoadingSSE) {
-      const originalContentString = getStringOrFirst(originalContent);
+      const originalContentString = originalContent;
       const encodedUrl = encodeStateToUrl(originalContentString, textSummaryResponse);
       history.replaceState({}, "", encodedUrl);
     }

--- a/src/components/utility-components/result/ShareLinkButton.tsx
+++ b/src/components/utility-components/result/ShareLinkButton.tsx
@@ -2,7 +2,6 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { ResponseType } from "~/types";
 import { encodeStateToUrl } from "~/utils/generateLinkToShare";
 import CopyUrlIcon from "../../../assets/copy-url-icon.svg";
-import { getStringOrFirst } from "~/typescript-helpers/type-cast-functions";
 
 const ShareLinkButton = ({
   originalContent,
@@ -10,7 +9,7 @@ const ShareLinkButton = ({
   disabled,
   trackShare,
 }: {
-  originalContent: string | string[];
+  originalContent: string;
   trackShare: (properties: { shareURL: string }) => void;
   responseObject: ResponseType;
   disabled?: boolean;
@@ -19,7 +18,7 @@ const ShareLinkButton = ({
   return (
     <button
       onClick={() => {
-        const originalContentString = getStringOrFirst(originalContent);
+        const originalContentString = originalContent;
         const encodedUrl = encodeStateToUrl(originalContentString, responseObject);
         copyToClipboard(encodedUrl);
         trackShare({ shareURL: encodedUrl });

--- a/src/hooks/useOpenAiSSEResponse.ts
+++ b/src/hooks/useOpenAiSSEResponse.ts
@@ -21,10 +21,12 @@ const useOpenAiSSEResponse = ({
   onSuccess,
   onStream,
   onError,
+  onReadability,
 }: {
   onSuccess?: (res: ResponseType) => unknown;
   onStream?: (res: ResponseType) => unknown;
   onError?: (error: { message: string }, data: RequestBody) => unknown;
+  onReadability?: (data: { [key: string]: string }) => unknown;
 }) => {
   const [streamedResult, setStreamedResult] = useState<string>("");
   const [isLoadingSSE, setIsLoadingSSE] = useState<boolean>(false);
@@ -35,10 +37,9 @@ const useOpenAiSSEResponse = ({
     dir: "",
     type: "article" as ContentType,
     byline: "",
-    // content: "",
+    content: "",
     url: "",
   };
-
   const initTextMappedPoints = {
     keyPoints: [""],
     bias: "",
@@ -67,14 +68,23 @@ const useOpenAiSSEResponse = ({
       let textContent = "";
       if (type === "article" || type === "song") {
         const json = await fetchArticleData(url, 500);
+        if (typeof onReadability === "function")
+          onReadability({
+            byline: json.byline,
+            title: json.title,
+            dir: json.dir,
+            url,
+            content: json.content,
+          });
+
         mappedResult.current = {
           ...mappedResult.current,
           byline: json.byline,
           title: json.title,
           dir: json.dir,
           url,
-          // content: json.content,
         };
+
         const body = await getSummaryFromUrl(type, json.chunkedTextContent);
         textContent = body;
       } else {
@@ -169,7 +179,7 @@ const useOpenAiSSEResponse = ({
     mutationFn: streamContent,
   });
 
-  return { streamedResult, mutate, isLoading, isLoadingSSE, isError, reset };
+  return { streamedResult, mutate, isLoading, isLoadingSSE, isError, readabilityData, reset };
 };
 
 export default useOpenAiSSEResponse;

--- a/src/pages/api/readability.ts
+++ b/src/pages/api/readability.ts
@@ -8,10 +8,8 @@ import { textToChunks } from "~/utils/text-to-chunks";
 // site.com/api/readability?url_resource="url"&chunk_length=30
 export default async function handler(req: NextApiRequest, res: NextApiResponse<DocumentResponseData | ErrorMessage>) {
   const { query, method } = req;
-
   const urlResource = getStringOrFirst(query.url_resource).replace(/['"]+/g, "");
   const chunkLength = +getStringOrFirst(query.chunk_length).replace(/['"]+/g, "");
-
   // Run function here on GET request
   if (method === "GET") {
     if (!urlResource) res.status(400).json({ message: "Please provide a valid URL", code: 400 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,7 @@ export interface TextResponse {
 export interface TextSummaryResponseType extends TextResponse {
   bias: string;
   title: string;
-  // content: string;
+  content: string;
   byline: string | null;
   dir: any; // not sure what this would be
   url: string;
@@ -100,7 +100,7 @@ export type SongMeaningResponseType = {
   byline: string | null;
   dir: any; // not sure what this would be
   meaning: string;
-  // content: string;
+  content: string;
   mood: string;
   moodColor: string;
   title: string;

--- a/src/utils/generate-song-url.ts
+++ b/src/utils/generate-song-url.ts
@@ -1,0 +1,5 @@
+export const generateSongUrl = (artistName: string, songTitle: string) => {
+  return `https://www.google.com/search?q=lyrics+to+${artistName.split(" ").join("-")}+${songTitle
+    .split(" ")
+    .join("-")}`;
+};

--- a/src/utils/generateLinkToShare.ts
+++ b/src/utils/generateLinkToShare.ts
@@ -2,8 +2,8 @@ import { ResponseType } from "~/types";
 
 export function encodeStateToUrl(originalContent: string, responseObject: ResponseType): string {
   const baseUrl = process.env.BASE_URL || window.location.origin;
-  const queryString = `?result=${encodeURIComponent(
-    JSON.stringify(responseObject),
-  )}&original=${encodeURIComponent(originalContent)}`;
+  const queryString = `?result=${encodeURIComponent(JSON.stringify(responseObject))}&original=${encodeURIComponent(
+    originalContent,
+  )}&type=${encodeURIComponent(responseObject.type)}`;
   return baseUrl + queryString;
 }

--- a/src/utils/open-ai-fetch.ts
+++ b/src/utils/open-ai-fetch.ts
@@ -39,6 +39,7 @@ async function callWithUrl(
       byline: json.byline,
       dir: json.dir,
       title: json.title,
+      content: json.content,
       url,
       trust: 0,
       ...response,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3851,6 +3851,11 @@ semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"


### PR DESCRIPTION
## WHAT IT DOES:

_Description of the pull request, what changed_
- pass readability content to original
- alter the way content is saved in url so that its parseable
- on load, if query params are in place and original is a url, parse the content with readability and return content as result
- there's an issue with jsdom and canvas. Added ignore to webpack config
- tailwindcss imports at top of global.css
- refactor the way `getStringOrFirst` is used throughout the file so it only gets called once from the parent.