### PR TITLE
fix(scrape-readability): check any status that is not 200

### DIFF
--- a/src/api-functions/readability/scrape-readability/index.ts
+++ b/src/api-functions/readability/scrape-readability/index.ts
@@ -18,7 +18,7 @@ const getHTML = async (url: string): Promise<string> => {
       headers: { "User-Agent": userAgent },
     });
 
-    if (res.status === 404) {
+    if (res.status !== 200) {
       // If googleusercontent cache search fails, use the raw url version.
       res = await fetch(url, {
         method: "get",


### PR DESCRIPTION
## WHAT IT DOES:
Api was only checking if res.status was 404 before using the raw url method to get content. This causes failed readability request because of other errors like 429.