### PR TITLE
Maia s/move to chat gpt prompt2

### DIFF
--- a/src/components/Input/InputPageHeader.tsx
+++ b/src/components/Input/InputPageHeader.tsx
@@ -5,7 +5,7 @@ import Container from "../utility-components/Container";
 
 const InputPageHeader = () => {
   return (
-    <header className="flex min-h-[14rem] w-full flex-col pt-12 md:pt-16">
+    <div className="flex min-h-[14rem] w-full flex-col pt-12 md:pt-16">
       <Container className="text-center">
         <div className="mx-auto flex w-full max-w-[100rem] items-end justify-between px-8 md:items-start md:px-0">
           <div className="relative w-[5.8rem] sm:w-[8rem] md:top-10 md:w-[14.5rem]">
@@ -22,7 +22,7 @@ const InputPageHeader = () => {
           Get an instant summary of any text, website content (URL) or song for free.
         </div>
       </Container>
-    </header>
+    </div>
   );
 };
 

--- a/src/hooks/useOpenAiSSEResponse.ts
+++ b/src/hooks/useOpenAiSSEResponse.ts
@@ -116,12 +116,15 @@ const useOpenAiSSEResponse = ({
 
         const text = JSON.parse(payload).choices?.[0]?.delta?.content ?? "";
         setStreamedResult((state) => {
-          const array = `${state}${text}`.split("%%");
+          const array = `${state}${text}`.split(/(KEYS:|TONE:|TRUST:|BIAS:)/i).reduce((acc: string[], value) => {
+            if (/(KEYS:|TONE:|TRUST:|BIAS:)/i.test(value)) return acc;
+            return [...acc, value];
+          }, []);
           if (type === "article" || type === "text")
             mappedResult.current = {
               ...mappedResult.current,
               summary: array?.[0],
-              keyPoints: array?.[1]?.split("|").filter((point) => point.trim() !== ""),
+              keyPoints: array?.[1]?.split("*>").filter((point) => point.trim() !== ""),
               bias: array?.[2],
               tone: array?.[3],
               trust: Number(array?.[4]),
@@ -135,6 +138,7 @@ const useOpenAiSSEResponse = ({
               moodColor: array?.[2],
             };
           onStream && onStream(mappedResult.current);
+
           return `${state}${text}`;
         });
       },

--- a/src/hooks/useOpenAiSSEResponse.ts
+++ b/src/hooks/useOpenAiSSEResponse.ts
@@ -2,6 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchArticleData } from "~/query/fetch-article-data";
 import {
+  ChatGPTModelRequest,
   ContentType,
   openAiModelRequest,
   RequestBody,
@@ -9,7 +10,12 @@ import {
   SongMeaningResponseType,
   TextSummaryResponseType,
 } from "~/types";
-import { generatePromptSongSSE, generatePromptTextSSE } from "~/utils/generatePrompt";
+import {
+  generatePromptSongSSE,
+  generatePromptSongSSEObjectArray,
+  generatePromptTextSSE,
+  generatePromptTextSSEObjectArray,
+} from "~/utils/generatePrompt";
 import { getSummaryFromUrl } from "~/utils/open-ai-fetch";
 import { fetchServerSent } from "~/utils/sse-fetch";
 import { textToChunks } from "~/utils/text-to-chunks";
@@ -71,27 +77,25 @@ const useOpenAiSSEResponse = ({
     const { wordLimit, type } = data;
     if (!data || !Object.keys(data).length) return;
 
-    const promptText =
-      type === "text"
-        ? generatePromptTextSSE(textContent, wordLimit)
-        : type === "article"
-        ? generatePromptTextSSE(textContent, wordLimit)
+    const promptObject =
+      type === "text" || type === "article"
+        ? generatePromptTextSSEObjectArray(textContent, wordLimit)
         : type === "song"
-        ? generatePromptSongSSE(textContent, wordLimit)
-        : "";
+        ? generatePromptSongSSEObjectArray(textContent, wordLimit)
+        : [];
 
     const multiplier = Math.min(wordLimit > 100 ? 2.5 : 1.3);
     const maxTokenLimit = Math.min(Math.round(wordLimit * multiplier) + 600, 2000);
-    const openAiPayload: openAiModelRequest = {
-      model: "text-davinci-003",
-      prompt: promptText,
+    const openAiPayload: ChatGPTModelRequest = {
+      model: "gpt-3.5-turbo",
+      messages: promptObject,
       max_tokens: maxTokenLimit,
       temperature: 0.2,
       presence_penalty: 0.5,
     };
 
     fetchRef.current = fetchServerSent(
-      "https://api.openai.com/v1/completions",
+      "https://api.openai.com/v1/chat/completions",
       {
         headers: {
           "Content-Type": "application/json",
@@ -109,7 +113,8 @@ const useOpenAiSSEResponse = ({
           onSuccess && onSuccess(mappedResult.current);
           return;
         }
-        const text = JSON.parse(payload).choices?.[0]?.text;
+
+        const text = JSON.parse(payload).choices?.[0]?.delta?.content ?? "";
         setStreamedResult((state) => {
           const array = `${state}${text}`.split("%%");
           if (type === "article" || type === "text")

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,9 +19,22 @@ export type DocumentResponseData = {
   chunkedTextContent: Array<string>;
 };
 
+export type ChatGPTPromptPropsItem = {
+  role: "user" | "system";
+  content: string;
+};
+
 export type openAiModelRequest = {
   model: string;
   prompt: string;
+  temperature: number;
+  max_tokens: number;
+  presence_penalty?: number;
+};
+
+export type ChatGPTModelRequest = {
+  model: "gpt-3.5-turbo";
+  messages: ChatGPTPromptPropsItem[];
   temperature: number;
   max_tokens: number;
   presence_penalty?: number;

--- a/src/utils/generatePrompt.ts
+++ b/src/utils/generatePrompt.ts
@@ -117,7 +117,9 @@ export function generatePromptSongSSEObjectArray(text: string, wordLimit: number
     { role: "user", content: text },
     {
       role: "system",
-      content: `${modifier(wordLimit)} ${wordLimit} word length summary of the meaning of the song lyrics submitted.`,
+      content: `${modifier(
+        wordLimit,
+      )} ${wordLimit} word length interpretation of the meaning of the song lyrics submitted.`,
     },
   ];
 }
@@ -126,17 +128,11 @@ export function generatePromptTextSSEObjectArray(text: string, wordLimit: number
   return [
     {
       role: "system",
-      content: `You are a CSV bot, you MUST use %% as the delimeter: ${modifier(
-        wordLimit,
-      )} summary of the incoming user text formatted as a csv with %% as the delimiter. Formatted like this:\n\n
-        summary%%keypoints%%bias%%tone%%trust\n
-        ${modifier(
-          wordLimit,
-        )} ${wordLimit} word length summary summarizing the text YOU MUST REACH ${wordLimit} words %% Array of Key Points of 70 words or less Separated by '|' %% 1 - 2 word string %% String %% number from 1 through 10, 10 is most trustworthy`,
+      content: `I want you to act as a new york times article author. Given the user text contained in curly braces respond with a short ${wordLimit} word article about the text. First generate the article summary, then generate a list of key points with "*>" as bullet the  under the key "KEYS", then generate a 1 word string of the bias under the key "BIAS", then generate a 1 word string of the tone under the key "TONE", then generate a 1 number verdict of trust out of 10 inclusive (10 is highest trust) under the key "TRUST"`,
     },
     {
       role: "user",
-      content: `Summarize this and output a CSV with %% as the delimiter, you MUST use %% as the delimeter: ${text}`,
+      content: `text: {${text}}`,
     },
   ];
 }

--- a/src/utils/generatePrompt.ts
+++ b/src/utils/generatePrompt.ts
@@ -1,3 +1,5 @@
+import { ChatGPTPromptPropsItem } from "~/types";
+
 export function generatePromptArticle(article: string | string[], wordLimit: number) {
   return `{${article}}
 
@@ -91,5 +93,50 @@ export const modifier = (wordLimit: number) => {
   if (wordLimit < 50) return "an extremely short";
   if (wordLimit < 100) return "a short";
   if (wordLimit < 200) return "a very detailed";
-  return "multiple paragraphs of an incredibly long, detailed, and verbose and longwinded text in the style of a new york times article";
+  return "multiple paragraphs of an incredibly long, detailed, and verbose and long-winded text in the style of a new york times article";
 };
+
+/* ------ Chat GPT Prompts below ------ */
+
+// As of March 8, 2023, chatGPT api docs recommends setting the system role to user to set more explicit instructions as sometimes the system prompt is ignored by some models
+
+// https://platform.openai.com/docs/guides/chat/instructing-chat-models
+
+export function generateCondensedSummaryPromptObjectArray(text: string, wordLimit: number): ChatGPTPromptPropsItem[] {
+  return [
+    { role: "user", content: text },
+    {
+      role: "user",
+      content: `generate an extremely short summary of up to ${wordLimit} words based on the text`,
+    },
+  ];
+}
+
+export function generatePromptSongSSEObjectArray(text: string, wordLimit: number): ChatGPTPromptPropsItem[] {
+  return [
+    { role: "user", content: text },
+    {
+      role: "system",
+      content: `${modifier(wordLimit)} ${wordLimit} word length summary of the meaning of the song lyrics submitted.`,
+    },
+  ];
+}
+
+export function generatePromptTextSSEObjectArray(text: string, wordLimit: number): ChatGPTPromptPropsItem[] {
+  return [
+    {
+      role: "system",
+      content: `You are a CSV bot, you MUST use %% as the delimeter: ${modifier(
+        wordLimit,
+      )} summary of the incoming user text formatted as a csv with %% as the delimiter. Formatted like this:\n\n
+        summary%%keypoints%%bias%%tone%%trust\n
+        ${modifier(
+          wordLimit,
+        )} ${wordLimit} word length summary summarizing the text YOU MUST REACH ${wordLimit} words %% Array of Key Points of 70 words or less Separated by '|' %% 1 - 2 word string %% String %% number from 1 through 10, 10 is most trustworthy`,
+    },
+    {
+      role: "user",
+      content: `Summarize this and output a CSV with %% as the delimiter, you MUST use %% as the delimeter: ${text}`,
+    },
+  ];
+}

--- a/src/utils/generatePrompt.ts
+++ b/src/utils/generatePrompt.ts
@@ -104,23 +104,23 @@ export const modifier = (wordLimit: number) => {
 
 export function generateCondensedSummaryPromptObjectArray(text: string, wordLimit: number): ChatGPTPromptPropsItem[] {
   return [
-    { role: "user", content: text },
     {
-      role: "user",
+      role: "system",
       content: `generate an extremely short summary of up to ${wordLimit} words based on the text`,
     },
+    { role: "user", content: text },
   ];
 }
 
 export function generatePromptSongSSEObjectArray(text: string, wordLimit: number): ChatGPTPromptPropsItem[] {
   return [
-    { role: "user", content: text },
     {
       role: "system",
       content: `${modifier(
         wordLimit,
       )} ${wordLimit} word length interpretation of the meaning of the song lyrics submitted.`,
     },
+    { role: "user", content: text },
   ];
 }
 


### PR DESCRIPTION
## WHAT IT DOES:
Trying to use a different prompt for chatGPT to compare. It moves away from forcing a CSV format in favor of a more loose key value pair.


> I want you to act as a new york times article author. Given the user text contained in curly braces respond with a short ${wordLimit} word article about the text. First generate the article summary, then generate a list of key points with "*>" as bullet the  under the key "KEYS", then generate a 1 word string of the bias under the key "BIAS", then generate a 1 word string of the tone under the key "TONE", then generate a 1 number verdict of trust out of 10 inclusive (10 is highest trust) under the key "TRUST"
