### PR TITLE
fix: move trackRequestCompleted inside useEffect hook in the result page

### DIFF
--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -45,14 +45,12 @@ export default function ClientPage({ searchParams }: { searchParams: { [key: str
     trackSubmit,
     trackNewSummary,
     trackRequestError,
-    trackRequestCompleted,
     trackShare,
   } = useAnalytics();
 
   const { mutate, isLoading, isLoadingSSE, streamedResult, forceClose, isError } = useOpenAiSSEResponse({
     onSuccess: (res: ResponseType) => {
       setLocalStorage(res);
-      trackRequestCompleted({ type: res.type, output: streamedResult });
     },
     onStream: (res) => {
       setDisplayResult(true);

--- a/src/components/Result/ResultContent/SongResult.tsx
+++ b/src/components/Result/ResultContent/SongResult.tsx
@@ -3,6 +3,7 @@ import { SongMeaningResponseType } from "~/types";
 import ShareLinkButton from "../../utility-components/result/ShareLinkButton";
 import { useEffect } from "react";
 import { encodeStateToUrl } from "~/utils/generateLinkToShare";
+import useAnalytics from "~/hooks/use-analytics";
 
 type SongResultPropType = {
   songMeaningResponse: SongMeaningResponseType;
@@ -19,9 +20,12 @@ const SongResult = ({
   isLoadingSSE,
   trackShare,
 }: SongResultPropType) => {
+  const { trackRequestCompleted } = useAnalytics();
+
   useEffect(() => {
     if (!isLoadingSSE) {
       const encodedUrl = encodeStateToUrl(originalContent, songMeaningResponse, songDetails);
+      trackRequestCompleted({ type: songMeaningResponse.type, output: songMeaningResponse.meaning });
       history.replaceState({}, "", encodedUrl);
     }
   }, [isLoadingSSE, originalContent, songDetails, songMeaningResponse]);

--- a/src/components/Result/ResultContent/TextResult.tsx
+++ b/src/components/Result/ResultContent/TextResult.tsx
@@ -3,6 +3,7 @@ import { TextSummaryResponseType, TextResponse } from "~/types";
 import ShareLinkButton from "../../utility-components/result/ShareLinkButton";
 import { useEffect } from "react";
 import { encodeStateToUrl } from "~/utils/generateLinkToShare";
+import useAnalytics from "~/hooks/use-analytics";
 
 type TextResultPropType = {
   originalContent: string;
@@ -12,10 +13,12 @@ type TextResultPropType = {
 };
 
 const TextResult = ({ originalContent, textSummaryResponse, isLoadingSSE, trackShare }: TextResultPropType) => {
+  const { trackRequestCompleted } = useAnalytics();
   useEffect(() => {
     if (!isLoadingSSE) {
       const originalContentString = originalContent;
       const encodedUrl = encodeStateToUrl(originalContentString, textSummaryResponse);
+      trackRequestCompleted({ type: textSummaryResponse.type, output: JSON.stringify(textSummaryResponse) });
       history.replaceState({}, "", encodedUrl);
     }
   }, [isLoadingSSE, originalContent, textSummaryResponse]);


### PR DESCRIPTION
## WHAT IT DOES:

_Description of the pull request, what changed_

Moved trackRequestCompleted inside useEffect hook in the result page

## HOW TO TEST:

_Description of how to test if applicable_
Submit a summary request, and it should be visible on Segment debugger
<img width="796" alt="image" src="https://user-images.githubusercontent.com/52301822/224115639-4e0b38de-443b-45fb-a329-e7973a9b9792.png">



