### PR TITLE
fix: remove spaces in regex to check https:// url

### DIFF
--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -79,7 +79,6 @@ export default function ClientPage({ searchParams }: { searchParams: { [key: str
     let validURL = inputUrl;
     // Readability requires us to send urls with the correct format, but because we want to support more forms of urls (google.com || www.google.com || https://www.google.com etc) we need to append the protocol before we send the data off.
     if (inputUrl && !/(https:\/\/)|(http:\/\/)/i.test(inputUrl)) {
-      console.log(validURL);
       validURL = "http://" + validURL;
     }
     event.preventDefault();

--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -78,7 +78,8 @@ export default function ClientPage({ searchParams }: { searchParams: { [key: str
   ) => {
     let validURL = inputUrl;
     // Readability requires us to send urls with the correct format, but because we want to support more forms of urls (google.com || www.google.com || https://www.google.com etc) we need to append the protocol before we send the data off.
-    if (inputUrl && !/(https:\/\/) | (http:\/\/)/i.test(inputUrl)) {
+    if (inputUrl && !/(https:\/\/)|(http:\/\/)/i.test(inputUrl)) {
+      console.log(validURL);
       validURL = "http://" + validURL;
     }
     event.preventDefault();


### PR DESCRIPTION
## WHAT IT DOES:

_Description of the pull request, what changed_
`/(https:\/\/) | (http:\/\/)/i` => `!/(https:\/\/)|(http:\/\/)/i`

spaces were throwing off the regex

## HOW TO TEST:
Enter article urls and songs and check the url by copying and pasting the code and seeing if it's valid (or looking at local storage `summaries` and checking the stored url)