### PR TITLE
Pratikmdhr/handle short articles

### DIFF
--- a/src/api-functions/open-ai-request/index.ts
+++ b/src/api-functions/open-ai-request/index.ts
@@ -18,6 +18,8 @@ async function getValidProps(type: ContentType, chunkedTextContent: Array<string
   switch (type) {
     case "text":
     case "song":
+      if (!chunkedTextContent || !chunkedTextContent.length) throw new Error("no data provided");
+      return chunkedTextContent;
     case "article":
       if (!chunkedTextContent || !chunkedTextContent.length) throw new Error("no data provided");
       if (chunkedTextContent[0].split(" ").length < 200) {
@@ -55,13 +57,8 @@ const openAICompletion = async (promptObject: ChatGPTPromptPropsItem[], max_toke
   return completion.data.choices?.[0]?.message?.content;
 };
 
-export async function getInsufficientLengthErrorMessage(
-  url: string,
-) {
-  const errorMessage = await openAICompletion(
-    generateInsufficientLengthErrorPromptObjectArray(url, 50),
-    50,
-  );
+export async function getInsufficientLengthErrorMessage(url: string) {
+  const errorMessage = await openAICompletion(generateInsufficientLengthErrorPromptObjectArray(url, 50), 50);
   return errorMessage;
 }
 

--- a/src/api-functions/open-ai-request/index.ts
+++ b/src/api-functions/open-ai-request/index.ts
@@ -3,6 +3,7 @@ import {
   generateCondensedSummaryPromptObjectArray,
   generatePromptSongSSEObjectArray,
   generatePromptTextSSEObjectArray,
+  generateInsufficientLengthErrorPromptObjectArray,
 } from "~/utils/generatePrompt";
 import {
   ChatGPTPromptPropsItem,
@@ -13,16 +14,15 @@ import {
   SongType,
 } from "~/types";
 
-function getValidProps(type: ContentType, chunkedTextContent: Array<string>) {
+async function getValidProps(type: ContentType, chunkedTextContent: Array<string>) {
   switch (type) {
     case "text":
     case "song":
     case "article":
       if (!chunkedTextContent || !chunkedTextContent.length) throw new Error("no data provided");
       if (chunkedTextContent[0].split(" ").length < 200) {
-        const error = new Error(
-          "The content of the URL you are trying to summarize is too short. Please try again with a different URL.",
-        );
+        const errorMessage = await getInsufficientLengthErrorMessage(type, chunkedTextContent);
+        const error = new Error(`${errorMessage}`);
         error.name = "insufficient length";
         throw error;
       }
@@ -50,8 +50,16 @@ const openAICompletion = async (promptObject: ChatGPTPromptPropsItem[], max_toke
   return completion.data.choices?.[0]?.message?.content;
 };
 
+export async function getInsufficientLengthErrorMessage(type: ContentType, chunkedTextContent: Array<string>) {
+  const errorMessage = await openAICompletion(
+    generateInsufficientLengthErrorPromptObjectArray(type, chunkedTextContent[0], 50),
+    50,
+  );
+  return errorMessage;
+}
+
 export async function openAiGetUseableTextContent(props: OpenAiSummarizeProps) {
-  const content = getValidProps(props.type, props.chunkedTextContent ?? []);
+  const content = await getValidProps(props.type, props.chunkedTextContent ?? []);
   let textContent = "";
   if (content.length > 1) {
     const promises = content.map(

--- a/src/api-functions/open-ai-request/index.ts
+++ b/src/api-functions/open-ai-request/index.ts
@@ -1,10 +1,7 @@
 import { Configuration, OpenAIApi } from "openai";
 import {
   generateCondensedSummaryPromptObjectArray,
-  generatePromptArticle,
-  generatePromptSong,
   generatePromptSongSSEObjectArray,
-  generatePromptText,
   generatePromptTextSSEObjectArray,
 } from "~/utils/generatePrompt";
 import {
@@ -22,6 +19,13 @@ function getValidProps(type: ContentType, chunkedTextContent: Array<string>) {
     case "song":
     case "article":
       if (!chunkedTextContent || !chunkedTextContent.length) throw new Error("no data provided");
+      if (chunkedTextContent[0].split(" ").length < 200) {
+        const error = new Error(
+          "The content of the URL you are trying to summarize is too short. Please try again with a different URL.",
+        );
+        error.name = "insufficient length";
+        throw error;
+      }
       return chunkedTextContent;
 
     default:

--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -16,6 +16,7 @@ import MinHeightBodyContainer from "~/components/utility-components/MinHeightBod
 
 export default function ClientPage({ searchParams }: { searchParams: { [key: string]: string } }) {
   const [originalContent, setOriginalContent] = useState(searchParams.original ?? "");
+  const [errorMessage, setErrorMessage] = useState<string>("");
 
   const {
     data: original,
@@ -60,6 +61,9 @@ export default function ClientPage({ searchParams }: { searchParams: { [key: str
       setDisplayOriginalContent(res.content);
     },
     onError: (err, data) => {
+      if (err?.name === "insufficient length") {
+        setErrorMessage(err?.message as string);
+      }
       setDisplayResult(false);
       trackRequestError({ ...data, error: (err?.message as string) ?? "" });
     },
@@ -118,7 +122,7 @@ export default function ClientPage({ searchParams }: { searchParams: { [key: str
       localStorage.setItem("summaries", JSON.stringify([newData]));
     }
   };
-  if (isError) return <Error handleNewSearchBtnClick={handleNewSearchBtnClick} />;
+  if (isError) return <Error handleNewSearchBtnClick={handleNewSearchBtnClick} errorMessage={errorMessage} />;
   if (isLoading || (!displayResult && isLoadingSSE))
     return (
       <Loading

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -1,16 +1,22 @@
-import Image from "next/image";
 import React from "react";
 import Container from "../utility-components/Container";
-import errorIcon from "../../assets/error.png";
 import ResultPageHeader from "../Result/ResultPageHeader";
 
-const Error = ({ handleNewSearchBtnClick }: { handleNewSearchBtnClick: () => void }) => {
+const Error = ({
+  handleNewSearchBtnClick,
+  errorMessage,
+}: {
+  handleNewSearchBtnClick: () => void;
+  errorMessage: string;
+}) => {
   return (
     <>
       <ResultPageHeader handleNewSearchBtnClick={handleNewSearchBtnClick} />
       <Container>
-        <div className="mx-auto mb-8 max-w-[75rem] animate-fadeIn rounded-[20px] border-2 border-primary bg-white py-12 px-8 md:my-20 md:p-20">
-          <p className="text-center text-[1.5rem] font-bold">Sorry, Something went wrong</p>
+        <div className="mx-auto my-8 max-w-[75rem] animate-fadeIn rounded-[20px] border-2 border-primary bg-white py-12 px-8 md:my-20 md:p-20">
+          <p className="text-center text-[1.5rem] font-bold">
+            {errorMessage.length ? errorMessage : "Sorry, Something went wrong"}
+          </p>
         </div>
       </Container>
     </>

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -14,7 +14,7 @@ const Error = ({
       <ResultPageHeader handleNewSearchBtnClick={handleNewSearchBtnClick} />
       <Container>
         <div className="mx-auto my-8 max-w-[75rem] animate-fadeIn rounded-[20px] border-2 border-primary bg-white py-12 px-8 md:my-20 md:p-20">
-          <p className="text-center text-[1.5rem] font-bold">
+          <p className={`text-[1.5rem] font-bold ${errorMessage.length ? "text-left" : "text-center"}`}>
             {errorMessage.length ? errorMessage : "Sorry, Something went wrong"}
           </p>
         </div>

--- a/src/hooks/useOpenAiSSEResponse.ts
+++ b/src/hooks/useOpenAiSSEResponse.ts
@@ -172,7 +172,7 @@ const useOpenAiSSEResponse = ({
               url,
               content: json.content,
             });
-          const body = await getSummaryFromUrl(type, json.chunkedTextContent);
+          const body = await getSummaryFromUrl(type, json.chunkedTextContent, url);
           textContent = body;
         } else {
           const chunkedText = textToChunks(text ?? "", 500);

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export type OpenAiRequestProps = {
 export type OpenAiSummarizeProps = {
   text?: string;
   maxToken?: number;
+  url?: string;
   chunkedTextContent?: Array<string>;
   wordLimit: number;
   type: ContentType;

--- a/src/utils/generatePrompt.ts
+++ b/src/utils/generatePrompt.ts
@@ -138,18 +138,17 @@ export function generatePromptTextSSEObjectArray(text: string, wordLimit: number
 }
 
 export function generateInsufficientLengthErrorPromptObjectArray(
-  type: string,
-  text: string,
+  url: string,
   wordLimit: number,
 ): ChatGPTPromptPropsItem[] {
   return [
     {
       role: "system",
-      content: `If the input text contains a URL that points to an article, generate a brief summary of the article consisting of two sentences, limited to a maximum of ${wordLimit} words. The first sentence should begin with "The article discusses," and the second sentence should say: "The content of the article you are trying to summarize is too short. Please try summarizing a different URL." If the input text does not contain a URL, simply return the second sentence of the summary.`,
+      content: `If the url points to an article and there is sufficient information available, generate a brief summary of the article consisting of two sentences, with the 1st sentence limited to a maximum of ${wordLimit} words. The 1st sentence should begin with "The article discusses," and the 2nd sentence should say: "The content of the article you are trying to summarize is too short. Please try summarizing using different URL." If there isn't sufficient information available, simply return the second sentence of the summary.`,
     },
     {
       role: "user",
-      content: `text: {${text}}`,
+      content: `url: {${url}}`,
     },
   ];
 }

--- a/src/utils/generatePrompt.ts
+++ b/src/utils/generatePrompt.ts
@@ -136,3 +136,20 @@ export function generatePromptTextSSEObjectArray(text: string, wordLimit: number
     },
   ];
 }
+
+export function generateInsufficientLengthErrorPromptObjectArray(
+  type: string,
+  text: string,
+  wordLimit: number,
+): ChatGPTPromptPropsItem[] {
+  return [
+    {
+      role: "system",
+      content: `If the input text contains a URL that points to an article, generate a brief summary of the article consisting of two sentences, limited to a maximum of ${wordLimit} words. The first sentence should begin with "The article discusses," and the second sentence should say: "The content of the article you are trying to summarize is too short. Please try summarizing a different URL." If the input text does not contain a URL, simply return the second sentence of the summary.`,
+    },
+    {
+      role: "user",
+      content: `text: {${text}}`,
+    },
+  ];
+}

--- a/src/utils/open-ai-fetch.ts
+++ b/src/utils/open-ai-fetch.ts
@@ -52,9 +52,9 @@ async function callWithUrl(
   }
 }
 
-async function getSummaryFromUrl(type: ContentType, chunkedTextContent: Array<string>) {
+async function getSummaryFromUrl(type: ContentType, chunkedTextContent: Array<string>, url?: string) {
   // if res is good, process in openAPI
-  return await summarizeChunkedContent(chunkedTextContent, 50, 50, type);
+  return await summarizeChunkedContent(chunkedTextContent, 50, 50, type, url);
 }
 
 async function summarizeChunkedContent(
@@ -62,12 +62,14 @@ async function summarizeChunkedContent(
   wordLimit: number,
   maxToken: number,
   type: ContentType,
+  url?: string,
 ): Promise<string> {
   const body = {
     type,
     chunkedTextContent,
     max_token: maxToken,
     wordLimit,
+    url
   };
   const response = (await openAiGetUseableTextContent(body)) as string;
   return response;


### PR DESCRIPTION
## WHAT IT DOES:

_Description of the pull request, what changed_
- Display error page if the article content is too short. 
- Get error message from openapi

## HOW TO TEST:

_Description of how to test if applicable_
Try entering an article from WSJ, NYT etc where the page is blocked. e.g https://www.wsj.com/articles/federal-reserve-rolls-out-emergency-measures-to-prevent-banking-crisis-ba4d7f98

### PREVIEW:

_Attach any relevant videos or images:_
<img width="994" alt="image" src="https://user-images.githubusercontent.com/52301822/225329449-e8f3f362-079d-4292-ac02-3407ece7003e.png">

---

