### PR TITLE
feat: limit input content length to 5000 words, pass input output cha…

### DIFF
--- a/src/api-functions/open-ai-request/index.ts
+++ b/src/api-functions/open-ai-request/index.ts
@@ -21,7 +21,7 @@ function checkIfChunkedContentExceedsLimit(chunkedTextContent: Array<string>) {
     const error = new Error(
       `Error content too long, content exceeds ${max_word_length} words, content length: ${totalWordsOfArticle}`,
     );
-    error.name = "insufficient length";
+    error.name = "Length constraint violation";
 
     throw error;
   }
@@ -43,7 +43,7 @@ async function getValidProps(type: ContentType, chunkedTextContent: Array<string
           errorMessage = await getInsufficientLengthErrorMessage(url);
         }
         const error = new Error(`${errorMessage}`);
-        error.name = "insufficient length";
+        error.name = "Length constraint violation";
         throw error;
       }
       checkIfChunkedContentExceedsLimit(chunkedTextContent);

--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -61,7 +61,7 @@ export default function ClientPage({ searchParams }: { searchParams: { [key: str
       setDisplayOriginalContent(res.content);
     },
     onError: (err, data) => {
-      if (err?.name === "insufficient length") {
+      if (err?.name === "Length constraint violation") {
         setErrorMessage(err?.message as string);
       }
       setDisplayResult(false);

--- a/src/components/Result/ResultContent/SongResult.tsx
+++ b/src/components/Result/ResultContent/SongResult.tsx
@@ -25,7 +25,12 @@ const SongResult = ({
   useEffect(() => {
     if (!isLoadingSSE) {
       const encodedUrl = encodeStateToUrl(originalContent, songMeaningResponse, songDetails);
-      trackRequestCompleted({ type: songMeaningResponse.type, output: songMeaningResponse.meaning });
+      trackRequestCompleted({
+        type: songMeaningResponse.type,
+        output: songMeaningResponse.meaning,
+        inputCharacterLength: songMeaningResponse.inputCharacterLength,
+        outputCharacterLength: songMeaningResponse.outputCharacterLength,
+      });
       history.replaceState({}, "", encodedUrl);
     }
   }, [isLoadingSSE, originalContent, songDetails, songMeaningResponse]);

--- a/src/components/Result/ResultContent/TextResult.tsx
+++ b/src/components/Result/ResultContent/TextResult.tsx
@@ -18,7 +18,12 @@ const TextResult = ({ originalContent, textSummaryResponse, isLoadingSSE, trackS
     if (!isLoadingSSE) {
       const originalContentString = originalContent;
       const encodedUrl = encodeStateToUrl(originalContentString, textSummaryResponse);
-      trackRequestCompleted({ type: textSummaryResponse.type, output: JSON.stringify(textSummaryResponse) });
+      trackRequestCompleted({
+        type: textSummaryResponse.type,
+        output: JSON.stringify(textSummaryResponse),
+        inputCharacterLength: textSummaryResponse.inputCharacterLength,
+        outputCharacterLength: textSummaryResponse.outputCharacterLength,
+      });
       history.replaceState({}, "", encodedUrl);
     }
   }, [isLoadingSSE, originalContent, textSummaryResponse]);

--- a/src/hooks/use-analytics.ts
+++ b/src/hooks/use-analytics.ts
@@ -47,7 +47,12 @@ const useAnalytics = () => {
   function trackNewSummary() {
     track(EVENT_NAMES.NEW_SUMMARY, {});
   }
-  function trackRequestCompleted(properties: { type: string; output: string }) {
+  function trackRequestCompleted(properties: {
+    type: string;
+    output: string;
+    inputCharacterLength: number;
+    outputCharacterLength: number;
+  }) {
     track(EVENT_NAMES.REQUEST_COMPLETED, properties);
   }
   function trackRequestError(properties: RequestBody & { error: string }) {

--- a/src/hooks/useOpenAiSSEResponse.ts
+++ b/src/hooks/useOpenAiSSEResponse.ts
@@ -4,18 +4,12 @@ import { fetchArticleData } from "~/query/fetch-article-data";
 import {
   ChatGPTModelRequest,
   ContentType,
-  openAiModelRequest,
   RequestBody,
   ResponseType,
   SongMeaningResponseType,
   TextSummaryResponseType,
 } from "~/types";
-import {
-  generatePromptSongSSE,
-  generatePromptSongSSEObjectArray,
-  generatePromptTextSSE,
-  generatePromptTextSSEObjectArray,
-} from "~/utils/generatePrompt";
+import { generatePromptSongSSEObjectArray, generatePromptTextSSEObjectArray } from "~/utils/generatePrompt";
 import { getSummaryFromUrl } from "~/utils/open-ai-fetch";
 import { fetchServerSent } from "~/utils/sse-fetch";
 import { textToChunks } from "~/utils/text-to-chunks";

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,8 @@ export interface TextResponse {
   tone: string;
   bias: string;
   trust: number;
+  inputCharacterLength: number;
+  outputCharacterLength: number;
   type: ContentType;
 }
 
@@ -118,6 +120,8 @@ export type SongMeaningResponseType = {
   moodColor: string;
   title: string;
   url: string;
+  inputCharacterLength: number;
+  outputCharacterLength: number;
   type: ContentType;
 };
 

--- a/src/utils/open-ai-fetch.ts
+++ b/src/utils/open-ai-fetch.ts
@@ -13,6 +13,8 @@ async function callWithText(text: string, wordLimit: number, type: ContentType):
     const validResponse = {
       type,
       trust: 0,
+      inputCharacterLength: text.length,
+      outputCharacterLength: JSON.stringify(response).length,
       ...response,
     };
     return { ...validResponse };
@@ -42,6 +44,8 @@ async function callWithUrl(
       content: json.content,
       url,
       trust: 0,
+      inputCharacterLength: json.chunkedTextContent?.reduce((acc, value) => (acc += value.length), 0),
+      outputCharacterLength: JSON.stringify(response).length,
       ...response,
     };
     return {


### PR DESCRIPTION
## WHAT IT DOES:

_Description of the pull request, what changed_
- Passes input and output character length on request complete analytics
- hard limit on text content 5000 words or less

## How to test:
- submit a request and check segment staging destination or network tab to see the inputCharacterLength and outputCharacterLength in properties.
- Try summarizing a very long article that contains over 5000 words in readability content