### PR TITLE
fix: song title, cleanup hook

### DIFF
--- a/src/app/clientPage.tsx
+++ b/src/app/clientPage.tsx
@@ -89,6 +89,7 @@ export default function ClientPage({ searchParams }: { searchParams: { [key: str
       wordLimit: Number(customLength || summaryLength),
       type,
       text,
+      title: songInfo,
     });
   };
   const handleNewSearchBtnClick = () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,13 @@
+import { ContentType, MarkdownResponse } from "./types";
+
+export const initTextMappedPoints = {
+  markdown: "",
+  inputCharacterLength: 0,
+  outputCharacterLength: 0,
+  title: "",
+  dir: "",
+  type: "article" as ContentType,
+  byline: "",
+  content: "",
+  url: "",
+} as MarkdownResponse;

--- a/src/hooks/useStreamOpenAI.ts
+++ b/src/hooks/useStreamOpenAI.ts
@@ -1,0 +1,89 @@
+import { useCallback, useRef, useState } from "react";
+import { initTextMappedPoints } from "~/constants";
+import { ChatGPTModelRequest, MarkdownResponse, RequestBody } from "~/types";
+import { buildPromptObject } from "~/utils/build-prompt-object";
+import { fetchServerSent } from "~/utils/sse-fetch";
+
+export function useStreamOpenAI() {
+  const [streamValue, setStreamValue] = useState<string>("");
+
+  const fetchRef = useRef<() => unknown>(() => null);
+
+  const streamContent = useCallback(
+    ({
+      data,
+      textContent,
+      callbackFunctions,
+    }: {
+      data: RequestBody;
+      textContent: string;
+      callbackFunctions: {
+        onSuccess?: (res: MarkdownResponse) => unknown;
+        onStream?: (res: MarkdownResponse) => unknown;
+        onError?: (error: { message: string; name?: string }, data: RequestBody) => unknown;
+      };
+    }) => {
+      const { onSuccess, onError, onStream } = callbackFunctions;
+      const { wordLimit, type, title = "" } = data;
+
+      setStreamValue("");
+
+      if (!data || !Object.keys(data).length) return;
+      const promptObject = buildPromptObject(type, textContent, wordLimit, title);
+
+      const multiplier = Math.min(wordLimit > 100 ? 2.5 : 1.3);
+      const maxTokenLimit = Math.min(Math.round(wordLimit * multiplier) + 600, 2000);
+      const openAiPayload: ChatGPTModelRequest = {
+        model: "gpt-3.5-turbo",
+        messages: promptObject,
+        max_tokens: maxTokenLimit,
+        temperature: 0.2,
+        presence_penalty: 0.5,
+      };
+      let mappedResult = initTextMappedPoints;
+      fetchRef.current = fetchServerSent(
+        "https://api.openai.com/v1/chat/completions",
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer " + process.env.NEXT_PUBLIC_OPENAI_API_KEY,
+          },
+          method: "POST",
+          payload: JSON.stringify({
+            ...openAiPayload,
+            stream: true,
+          }),
+        },
+        (payload) => {
+          if ((payload as string) === "[DONE]") {
+            onSuccess && onSuccess(mappedResult);
+            return;
+          }
+
+          const text = JSON.parse(payload as string).choices?.[0]?.delta?.content ?? "";
+          setStreamValue((state) => {
+            mappedResult = {
+              ...mappedResult,
+              markdown: `${state}${text}`,
+              outputCharacterLength: `${state}${text}`.length,
+              type,
+            };
+
+            onStream && onStream(mappedResult);
+
+            return `${state}${text}`;
+          });
+        },
+        (err) => {
+          onError && onError(err as { message: string }, data);
+        },
+      );
+    },
+    [],
+  );
+  return {
+    resetStream: fetchRef.current,
+    streamValue,
+    stream: streamContent,
+  };
+}

--- a/src/query/fetch-article-data.ts
+++ b/src/query/fetch-article-data.ts
@@ -2,5 +2,6 @@ import { DocumentResponseData } from "~/types";
 
 export const fetchArticleData = async (urlResource: string, chunkLength: number): Promise<DocumentResponseData> => {
   const res = await fetch(`/api/readability?url_resource="${urlResource}"&chunk_length=${chunkLength}`);
+
   return await res.json();
 };

--- a/src/test-utils/mocks/readabilityDataMock.ts
+++ b/src/test-utils/mocks/readabilityDataMock.ts
@@ -1,0 +1,27 @@
+export const readability_song = {
+  url: "https://www.google.com/search?q=lyrics to Britney-Spears Oops!…I-Did-It-Again",
+  chunkedTextContent: ["chunked text content"],
+  title: "lyrics to Britney-Spears Oops!…I-Did-It-Again - Google Search",
+  byline: null,
+  dir: null,
+  lang: "en",
+  content: "CONTENT",
+  textContent: "raw text content",
+  length: 1666,
+  excerpt: "Yeah yeah yeah yeah yeahYeah yeah yeah yeah yeah yeah",
+  siteName: null,
+};
+
+export const readability_article = {
+  url: "http://medium.com/@pravse/the-maze-is-in-the-mouse-980c57cfd61a",
+  chunkedTextContent: ["1", "2", "3"],
+  title: "The maze is in the mouse - Praveen Seshadri - Medium",
+  byline: "Praveen Seshadri",
+  dir: null,
+  lang: "en",
+  textContent: "raw text content",
+  content: "CONTENT",
+  length: 21545,
+  excerpt: "What ails Google. And how it can turn it around.",
+  siteName: "Medium",
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export type RequestBody = {
   text?: string;
   type: ContentType;
   wordLimit: number;
+  title?: string;
 };
 
 export type OpenAiRequestProps = {

--- a/src/utils/build-content-to-stream.spec.ts
+++ b/src/utils/build-content-to-stream.spec.ts
@@ -1,0 +1,31 @@
+import { readability_article } from "~/test-utils/mocks/readabilityDataMock";
+import { buildContentToStream } from "./build-content-to-stream";
+
+jest.mock("~/query/fetch-article-data", () => {
+  return {
+    fetchArticleData: () => readability_article,
+  };
+});
+
+jest.mock("./open-ai-fetch", () => {
+  return { getSummaryFromUrl: () => "Summarized Content" };
+});
+
+describe("Expect buildContentToStream to work correctly", () => {
+  it("returns correct objects", async () => {
+    expect(await buildContentToStream("article", readability_article.url, "")).toMatchObject({
+      mappedReadabilityObject: {
+        type: "article",
+        inputCharacterLength: 3,
+        outputCharacterLength: 0,
+        byline: readability_article.byline,
+        title: readability_article.title,
+        dir: readability_article.dir,
+        content: readability_article.content,
+        url: readability_article.url,
+        markdown: "",
+      },
+      textContent: "Summarized Content",
+    });
+  });
+});

--- a/src/utils/build-content-to-stream.ts
+++ b/src/utils/build-content-to-stream.ts
@@ -1,0 +1,51 @@
+import { initTextMappedPoints } from "~/constants";
+import { fetchArticleData } from "~/query/fetch-article-data";
+import { ContentType } from "~/types";
+import { getSummaryFromUrl } from "./open-ai-fetch";
+import { textToChunks } from "./text-to-chunks";
+
+/**
+ *
+ * @param type
+ * @param url
+ * @param text
+ * build readability data for useOpenAISSEResponse hook
+ */
+export const buildContentToStream = async (type: ContentType, url: string, text: string) => {
+  let textContent = "";
+
+  let mappedReadabilityObject = { ...initTextMappedPoints };
+  try {
+    if (type === "article" || type === "song") {
+      const json = await fetchArticleData(url, 500);
+      const inputCharacterLength = json.chunkedTextContent?.reduce((acc, value) => (acc += value.length), 0);
+
+      mappedReadabilityObject = {
+        ...mappedReadabilityObject,
+        type,
+        inputCharacterLength,
+        byline: json.byline,
+        title: json.title,
+        dir: json.dir,
+        content: json.content,
+        url,
+      };
+
+      const body = await getSummaryFromUrl(type, json.chunkedTextContent, url);
+      textContent = body;
+    } else {
+      const chunkedText = textToChunks(text ?? "", 500);
+      const inputCharacterLength = chunkedText?.reduce((acc, value) => (acc += value.length), 0);
+      mappedReadabilityObject = {
+        ...mappedReadabilityObject,
+        inputCharacterLength,
+      };
+      textContent = await getSummaryFromUrl(type, chunkedText);
+    }
+
+    return { textContent, mappedReadabilityObject };
+  } catch (err) {
+    const error = err as { message: string; name?: string };
+    throw error;
+  }
+};

--- a/src/utils/build-prompt-object.ts
+++ b/src/utils/build-prompt-object.ts
@@ -1,0 +1,7 @@
+import { generatePromptSongMarkdown, generateTextSummaryMarkdown } from "./generatePrompt";
+
+export function buildPromptObject(type: string, textContent: string, wordLimit: number, title: string) {
+  if (type === "text" || type === "article") return generateTextSummaryMarkdown(textContent, wordLimit);
+  else if (type === "song") return generatePromptSongMarkdown(textContent, wordLimit, title);
+  else return [];
+}

--- a/src/utils/generatePrompt.ts
+++ b/src/utils/generatePrompt.ts
@@ -43,7 +43,7 @@ export function generateTextSummaryMarkdown(text: string, wordLimit: number): Ch
     {
       role: "system",
       content: `Generate a markdown summary of the following user text content following this format.
-      
+    
       ## (Title of summary)
       summary content (${markdownModifier(wordLimit)})
       \n\n
@@ -61,16 +61,19 @@ export function generateTextSummaryMarkdown(text: string, wordLimit: number): Ch
   ];
 }
 
-export function generatePromptSongMarkdown(text: string, wordLimit: number): ChatGPTPromptPropsItem[] {
+export function generatePromptSongMarkdown(text: string, wordLimit: number, title?: string): ChatGPTPromptPropsItem[] {
   return [
     {
       role: "system",
-      content: `Generate a markdown interpretation of the meaning of the song lyrics submitted following this format
+      content: `Generate a markdown interpretation of the meaning of the ${
+        title ? `song "${title}"` : "content"
+      } submitted following this format:
         
-        ## (Title)
-        interpretation of the meaning of the song (${markdownModifier(wordLimit)})
+        ## ${title ? `(Title of song and artist ${title})` : "Title Evoked by interpretation"}
+        
+        interpretation of the meaning of the content (${markdownModifier(wordLimit)})
 
-       - Mood evoked by song: {mood}
+       - Mood evoked by lyrics: {mood}
         `,
     },
     { role: "user", content: text },


### PR DESCRIPTION
## WHAT IT DOES:

_Description of the pull request, what changed_
Appends song title and artist to prompt generation. This should help decrease LLM hallucinations when not knowing the song title or artist

## HOW TO TEST:
_Description of how to test if applicable_
Choose song, input a song that is newer than 2021 ([here's a list](https://www.google.com/search?q=songs+that+came+out+in+2023&rlz=1C5CHFA_enUS997US997&oq=songs+th&aqs=chrome.0.69i59j69i57j0i512l3j69i60l2j69i61.3174j0j7&sourceid=chrome&ie=UTF-8)) Choose a song with a newer artist as well.